### PR TITLE
fix: Adjust the Alpine version and adapt the allocated database ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ You can execute `docker-compose up -d --build --force-recreate` to start and bui
 
 ### Version information
 
-| **Version** |    **Description**     |
-|:-----------:|:----------------------:|
-|    1.1.0    | Includes PostgreSQL 16 |
-|    1.0.0    | Includes PostgreSQL 13 |
+| **Version** |                         **Description**                          |
+|:-----------:|:----------------------------------------------------------------:|
+|    1.1.1    | Update the Alpine version and the allocated IPs of the databases |
+|    1.1.0    |                      Includes PostgreSQL 16                      |
+|    1.0.0    |                      Includes PostgreSQL 13                      |
 
 ### Cronjobs
 
-It is possible to adapt the `pretixuser` crontab entries by modifying the [crontab](docker/pretix/crontab.bak) file.
+It is possible to adapt the `pretixuser` crontab entries by modifying the [crontab](docker/pretix/crontab) file.
 
 ## TLS setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - backend
 
   database:
-    image: postgres:16-alpine3.20
+    image: postgres:16-alpine3.22
     container_name: database
     ports:
       - "5432:5432"
@@ -34,7 +34,7 @@ services:
       - backend
 
   cache:
-    image: redis:alpine3.20
+    image: redis:alpine3.22
     container_name: redis
     ports:
       - "6379:6379"
@@ -50,4 +50,6 @@ volumes:
 
 networks:
   backend:
-    external: false
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"


### PR DESCRIPTION
### Upgrade Alpine Images and Improve Network Configuration

#### What's Changed

- **PostgreSQL & Redis Containers:**
  - Upgraded from `alpine3.20` to `alpine3.22` for enhanced security and compatibility.

- **Docker Networking:**
  - The backend network now uses the `bridge` driver and binds to `127.0.0.1`. This limits database and cache exposure to localhost only for better security.

- **Documentation:**
  - Updated the README to reflect these changes, listing version `1.1.1` as the latest.
  - Fixed the reference path for editing user crontab files.

#### Rationale

Keeping dependencies up to date improves stability and security. The network change ensures that the database and cache services are only accessible from the host machine, reducing unintended exposure. Documentation changes keep user instructions accurate.

---

**Ready for review and merge!**